### PR TITLE
Infra: ECS 작업 정의에 시간대 환경 변수 추가 (Asia/Seoul)

### DIFF
--- a/infra/terraform/ecs.tf
+++ b/infra/terraform/ecs.tf
@@ -82,7 +82,8 @@ resource "aws_ecs_task_definition" "main" {
         { name = "DB_HOST", value = aws_db_instance.main.address },
         { name = "DB_NAME", value = var.db_name },
         { name = "DB_USERNAME", value = var.db_username },
-        { name = "DB_PASSWORD", value = var.db_password }
+        { name = "DB_PASSWORD", value = var.db_password },
+        { name = "TZ", value = "Asia/Seoul" },
       ]
       logConfiguration = {
         logDriver = "awslogs"
@@ -119,7 +120,8 @@ resource "aws_ecs_task_definition" "emulator" {
         }
       ]
       environment = [
-        { name = "KAFKA_BOOTSTRAP_SERVERS", value = "${aws_instance.kafka_server.private_ip}:9092" }
+        { name = "KAFKA_BOOTSTRAP_SERVERS", value = "${aws_instance.kafka_server.private_ip}:9092" },
+        { name = "TZ", value = "Asia/Seoul" },
       ]
       logConfiguration = {
         logDriver = "awslogs"
@@ -155,7 +157,8 @@ resource "aws_ecs_task_definition" "consumer" {
         { name = "DB_NAME", value = var.db_name },
         { name = "DB_USERNAME", value = var.db_username },
         { name = "DB_PASSWORD", value = var.db_password },
-        { name = "KAFKA_BOOTSTRAP_SERVERS", value = "${aws_instance.kafka_server.private_ip}:9092" }
+        { name = "KAFKA_BOOTSTRAP_SERVERS", value = "${aws_instance.kafka_server.private_ip}:9092" },
+        { name = "TZ", value = "Asia/Seoul" },
       ]
       logConfiguration = {
         logDriver = "awslogs"

--- a/infra/terraform/route53.tf
+++ b/infra/terraform/route53.tf
@@ -69,8 +69,15 @@ resource "aws_acm_certificate_validation" "alb" {
 # S3 정적 사이트를 위한 CloudFront 배포
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = aws_s3_bucket.my_bucket.bucket_regional_domain_name
+    domain_name = aws_s3_bucket.my_bucket.website_endpoint
     origin_id   = "S3-${var.domain_name}"
+
+    custom_origin_config {
+      origin_protocol_policy = "http-only"
+      http_port              = 80
+      https_port             = 443
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
   }
 
   enabled             = true


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- [ ] #149


## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [ ] `ecs.tf` 에서 `TZ` 환경변수에 `Asia/Seoul` 값 추가함으로 서버 시간대를 KST 로 수정


## 💬 참고 사항(선택)
> 예시) 해당 메서드 이름이 적절한가요?
